### PR TITLE
Fix comparing fresh doses by time

### DIFF
--- a/app/src/commonMain/kotlin/net/cacheux/nvp/app/StorageRepository.kt
+++ b/app/src/commonMain/kotlin/net/cacheux/nvp/app/StorageRepository.kt
@@ -48,8 +48,11 @@ class StorageRepository(
         if (result is PenResult.Success) {
             val lastTime = storage.getLastDose(result.data.serial).first()?.time ?: 0L
             result.data.doseList.forEach { dose ->
-                if (dose.time > lastTime)
+                // The same dose can be read with different ms.
+                // Rare chance to have both doses in less than the same second.
+                if ((dose.time - lastTime) > 1000) {
                     storage.addDose(Dose(dose.time, dose.units), result.data.penInfos())
+                }
             }
         }
     }

--- a/app/src/desktopTest/kotlin/net/cacheux/nvp/app/StorageRepositoryTest.kt
+++ b/app/src/desktopTest/kotlin/net/cacheux/nvp/app/StorageRepositoryTest.kt
@@ -4,6 +4,9 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import net.cacheux.nvp.model.Dose
 import net.cacheux.nvp.model.PenInfos
+import net.cacheux.nvplib.data.InsulinDose
+import net.cacheux.nvplib.data.PenResult
+import net.cacheux.nvplib.data.PenResultData
 import net.cacheux.nvplib.storage.DoseStorage
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -15,7 +18,7 @@ import org.mockito.kotlin.verify
 class StorageRepositoryTest {
 
     @Test
-    fun saveDoseList() = runBlocking {
+    fun testSaveDoseList() = runBlocking {
         val mockDoseStorage = mock<DoseStorage> {
             on { getAllDoses() }.thenReturn(
                 flowOf(
@@ -51,5 +54,35 @@ class StorageRepositoryTest {
         verify(mockDoseStorage, times(2)).addDose(
             eq(Dose(12346666L, 10, serial = "ABCD")), eq(PenInfos(serial = "ABCD"))
         )
+    }
+
+    @Test
+    fun testSaveResult() = runBlocking {
+        val mockDoseStorage = mock<DoseStorage> {
+            on { getLastDose(any()) }.thenReturn(flowOf(Dose(12345678L, 20, serial = "ABCD")))
+        }
+
+        val storageRepository = StorageRepository(mockDoseStorage)
+
+        storageRepository.saveResult(PenResult.Success(
+            PenResultData(
+                model = "NovoPen", serial = "ABCD",
+                startTime = 12345676L,
+                doseList = listOf(
+                    InsulinDose(12360908L, 70, 0),
+                    InsulinDose(12360908L, 60, 0),
+                    InsulinDose(12356008L, 50, 0),
+                    InsulinDose(12355679L, 40, 0),
+                    InsulinDose(12345679L, 20, 0), // Ignored
+                    InsulinDose(12345676L, 10, 0), // Ignored
+                )
+            )
+        ))
+
+        verify(mockDoseStorage, times(4)).addDose(any(), any())
+        verify(mockDoseStorage, times(1)).addDose(eq(Dose(12355679L, 40)), any())
+        verify(mockDoseStorage, times(1)).addDose(eq(Dose(12356008L, 50)), any())
+        verify(mockDoseStorage, times(1)).addDose(eq(Dose(12360908L, 60)), any())
+        verify(mockDoseStorage, times(1)).addDose(eq(Dose(12360908L, 70)), any())
     }
 }


### PR DESCRIPTION
Hi!

I started to use application and found a bug when the same dose is doubled. During investigation in app's database I realized, that the same dose is stored with different value of ms. It's happening often more than half of new scanning attempts.

I made a fix that considers a new dose should be newer more that 1 second.

Screenshots

![database](https://github.com/user-attachments/assets/51d8ea63-519f-4f4f-85db-ae260ec44d7d)
![app](https://github.com/user-attachments/assets/703da776-5f73-4134-bf05-8270c8001b12)


